### PR TITLE
ID review edits

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,27 +8,27 @@
 :projectid: mp-metrics
 :page-layout: guide
 :page-duration: 20 minutes
-:page-description: Learn how to provide system and application metrics from a microservice using MicroProfile Metrics.
+:page-description: Learn how to provide system and application metrics from a microservice with MicroProfile Metrics.
 :page-tags: ['Metrics' , 'MicroProfile' , 'CDI', '@Timed', '@Counted', '@Gauge', 'REST']
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
 = Providing metrics from a microservice
 
-Learn how to provide system and application metrics from a microservice using MicroProfile Metrics.
+Learn how to provide system and application metrics from a microservice with MicroProfile Metrics.
 
 == What you'll learn
 
 You will learn how to use MicroProfile Metrics to provide metrics from a RESTful application.
-Having metrics in an application serves to pinpoint issues and provides long term trend data for
-capacity planning and pro-active discovery of issues such as disk usage growing without bounds. They can
-also help those scheduling systems to decide when to scale the application to run on more or fewer machines.
+Include metrics in an application to pinpoint issues, provide long-term trend data for
+capacity planning, and provide proactive discovery of issues, such as disk usage growth without bounds. Metrics can
+also help you schedule systems and decide when to scale the application to run on more or fewer machines.
 
-MicroProfile Metrics provides an endpoint where you can get the metrics
-results as a plain text format. This endpoint has three scopes: base, application and vendor.
-For the purpose of this guide, the focus is on the application scope. The metadata of the metrics in
-any scope has fields such as unit, type, description, etc. The type can be a counter, gauge,
-meter, histogram and timer. You will use the counter, gauge and timer types in your application.
+Use the MicroProfile Metrics endpoint to get metrics
+results in a plain text format. The endpoint has three scopes: base, application, and vendor.
+This guide focuses on the application scope. The metrics metadata in
+any scope has fields, such as unit, type, and description. The type can be a counter, gauge,
+meter, histogram, or timer. You will use the counter, gauge, and timer types in your application.
 
 The application that you will be working with is an `inventory` service, which stores the information
 about various JVMs that run on different systems. Whenever a request is made to the `inventory`
@@ -36,7 +36,7 @@ service to retrieve the JVM system properties of a particular host, the `invento
 communicates with the `system` service on that host to get these system properties.
 The system properties are then stored and returned.
 
-You will apply the 'metrics type annotations' to the inventory application in order to provide metrics
+You will apply the 'metrics type annotations' to the inventory application to provide metrics
 at the application scope.
 
 // =================================================================================================
@@ -45,8 +45,8 @@ at the application scope.
 
 == Getting started
 
-The fastest way to work through this guide is to clone the Git repository and use the starting project
-that is provided in the `start` directory. To do this, run the following commands:
+Clone the Git repository. Then, use the starting project
+that is provided in the `start` directory by running the following commands:
 
 [subs="attributes"]
 ----
@@ -60,26 +60,26 @@ cd draft-guide-microprofile-metrics/start
 
 === Try what you'll build
 
-The `finish` directory in the root of this guide contains the finished metrics implementation
-for the application. Feel free to give it a try before you proceed with building your own.
+The `finish` directory contains the finished metrics implementation
+for the application. You can try it out before you build your own.
 
-To try out the application, first navigate to the `finish` directory and then run the following.
-Maven aims to build the application and run it inside Open Liberty:
+To try the application, navigate to the `finish` directory and then run the following command.
+Maven aims to build the application and run it inside of Open Liberty:
 
 ```
 mvn install liberty:start-server
 ```
 
-Point your browser to `http://localhost:9080/inventory/systems`. As you can see, there are no
-hosts registered currently since you have just started the application. Point to
+Point your browser to `http://localhost:9080/inventory/systems`. Because you just started the application, no
+hosts are currently registered. Point to the
 `http://localhost:9080/metrics` MicroProfile Metrics endpoint. Use `confAdmin` and `microprofile` as 
-the credentials to log in. From here, you can see the standard metrics, and also includes 
-the application metrics, in Prometheus format.
-Point to `http://localhost:9080/metrics/application` to see application metrics only. The
-application metrics will not show up if you do not point your browser first to
-`http://localhost:9080/inventory/systems`. This is because these metrics are application related.
+the credentials to log in. From here, you can see both the standard metrics and 
+the application metrics in Prometheus format.
+Point to `http://localhost:9080/metrics/application` to see only application metrics. The
+application metrics appear only if you first point your browser to
+`http://localhost:9080/inventory/systems` because these metrics are application-related.
 
-Once you are done checking out the application, stop the Open Liberty server:
+When you're done checking out the application, stop the Open Liberty server with the following command:
 
 ```
 mvn liberty:stop-server
@@ -88,29 +88,29 @@ mvn liberty:stop-server
 Now, navigate back to the `start` directory to begin.
 
 // =================================================================================================
-// Adding Microprofile Metrics to inventory application
+// Adding Microprofile Metrics to inventory applications
 // =================================================================================================
 
-== Adding Microprofile Metrics to inventory application
+== Adding Microprofile Metrics to inventory applications
 
-Begin by navigating to the `pom.xml` file to check the required dependency. The `microprofile-health-api` 
-dependency has been added for you in the `start/pom.xml` file. This dependency allows you to
-use the MicroProfile Metrics API to provide the metrics from your RESTful services. Also, the system property `javax.net.ssl.trustStore` was set for you to point to the SSL certificate.
+Navigate to the `pom.xml` file to check the required dependency. The `microprofile-health-api` 
+dependency is added for you in the `start/pom.xml` file. This dependency allows you to
+use the MicroProfile Metrics API to provide the metrics from your RESTful services. Also, the `javax.net.ssl.trustStore` system property  is set for you to point to the SSL certificate.
 
-Create `start/src/main/liberty/config/server.xml`:
+Create a `start/src/main/liberty/config/server.xml` file:
 
 [source, xml, indent=0]
 ----
 include::finish/src/main/liberty/config/server.xml[tags=server]
 ----
 
-The `mpMetrics-1.0` feature provides `http://localhost:9080/metrics` endpoint.
+The `mpMetrics-1.0` feature provides the `http://localhost:9080/metrics` endpoint.
 
-This feature also requires you to secure this endpoint. The `quickStartSecurity` and `keyStore` 
-configurations elements allow you to add a basic security to this application. Use these 
+This feature also requires you to secure this endpoint. Use the `quickStartSecurity` and `keyStore` 
+configuration elements to add basic security to the application. Use these 
 credentials to view the metrics endpoint when you browse it.
 
-Proceed with the section below to add the metrics using the annotations.
+The next section covers adding the metrics with the annotations.
 
 // =================================================================================================
 // Adding metrics to the @timed and @counted annotations
@@ -118,36 +118,36 @@ Proceed with the section below to add the metrics using the annotations.
 
 === Adding the @timed and @counted annotations
 
-Create the class `/start/src/main/java/io/openliberty/guides/inventory/InventoryManager.java`:
+Create the `/start/src/main/java/io/openliberty/guides/inventory/InventoryManager.java` class:
 
 [source, java, indent=0]
 ----
 include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[tags=InventoryManager]
 ----
 
-As you can see, there are two metrics annotations:
+You have two metrics annotations:
 
-`@Timed` is a metric annotation that applies on the `get()` method to track how frequently the method is
+`@Timed` is a metric annotation that applies to the `get()` method to track how frequently the method is
 invoked and also how long it took for the invocation to complete. Most of the annotations are
-followed by fields that correspond to metadata fields and some of them are provided by default
-and others are just optional. Timer is a complex metric type comprised of multiple key/values.
+followed by fields that correspond to metadata fields. Some of the annotations are provided by default,
+and others are optional. Timer is a complex metric type comprised of multiple keys and values.
 The `name` field sets the name of the metric. If not explicitly given, the name of the annotated
-method is used. For the `@Timed` annotation the default value of `unit` is `seconds`. The
-`description` field is optional and it provides a brief description of the purpose of the metric
-annotation.
+method is used. For the `@Timed` annotation, the default value of `unit` is `seconds`. The
+`description` field is optional, and it provides a brief description of the metric
+annotation's purpose.
 
-`@Counted` is a metric annotation that applies on the `list()` method to count how many times the list of systems
-method is requested. In other words, how many times we display the current contents of the
-inventory by going to `http://localhost:9080/inventory/systems`. The `absolute` field is used to make the name of
+`@Counted` is a metric annotation that applies to the `list()` method to count how many times the list of systems
+method is requested. In other words, how many times you display the current contents of the
+inventory by visiting `http://localhost:9080/inventory/systems`. The `absolute` field makes the name of
 this annotation take the name of the method. Like the previous annotation, this annotation has
-a `description` field too. The `monotonic` field has a default value `false`
+a `description` field. The `monotonic` field has a default value of `false`,
 which means that the counter is incremented before the annotated method returns, counting current
-invocations of the annotated method. This is not what we want in this case, thus set the value
-to `true`.
+invocations of the annotated method. In this case, however, set the value
+to `true` instead.
 
 === Adding the @Gauge annotation
 
-Create the class `/start/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java`:
+Create the `/start/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java` class:
 
 [source, java, indent=0]
 ----
@@ -155,12 +155,11 @@ include::finish/src/main/java/io/openliberty/guides/inventory/model/InventoryLis
 ----
 
 The `@Gauge` annotation on the `getTotal()` method tracks the number of systems stored
-in the inventory (or tracks the inventory size). A system is stored in the inventory when you visit
-`http://localhost:9080/inventory/systems/localhost`. The `unit` field must be specified because there
-is no default value for this annotation. The `name` and `description` are optional like in
-the previous two annotations.
+in the inventory or tracks the inventory size. A system is stored in the inventory when you visit
+`http://localhost:9080/inventory/systems/localhost`. Specify the `unit` field because this
+annotation has no default value. The `name` and `description` fields are optional.
 
-These three annotations are registered by default to the singleton object `MetricRegistry`.
+These three annotations are registered by default to the `MetricRegistry` singleton object.
 Through this object, they send their metadata or metrics to `http://localhost:9080/metrics/application`.
 
 This application is provided for you in this guide.
@@ -179,7 +178,7 @@ To build the application, run the Maven install goal from the command line:
   mvn install
 ```
 
-This goal builds the application and creates a .war file in the target directory and also
+This goal builds the application, creates a .war file in the target directory, and 
 configures and installs Open Liberty into the target/liberty/wlp directory.
 
 Next, run the Maven liberty:start-server goal:
@@ -188,10 +187,10 @@ Next, run the Maven liberty:start-server goal:
   mvn liberty:start-server
 ```
 
-This goal starts an Open Liberty server instance. Your Maven `pom.xml` is already configured to
+This goal starts an Open Liberty server instance. Your Maven `pom.xml` file is already configured to
 start the application in this server instance.
 
-Once the server is running, you can find the metrics endpoint showing useful JVM/server base
+When the server runs, you can find the metrics endpoint that shows JVM and server base
 details at the following URL:
 
 * `http://localhost:9080/metrics`
@@ -201,12 +200,12 @@ metrics about your application at the following URL:
 
 * `http://localhost:9080/metrics/application`
 
-If you make changes to the code, use the Maven package command to rebuild the application and have
-the running Open Liberty server pick them up automatically:
+If you make changes to the code, use the Maven package command to rebuild the application:
 
 ```
   mvn package
 ```
+The running Open Liberty server automatically picks up the changes.
 
 To stop the Open Liberty server, run the Maven liberty:stop-server goal:
 
@@ -220,11 +219,11 @@ To stop the Open Liberty server, run the Maven liberty:stop-server goal:
 
 == Testing the metrics
 
-While you can test your application manually, you should rely on automated tests since they will
+Although you can test your application manually, use automated tests because they 
 trigger a failure whenever a code change introduces a defect. JUnit and the JAX-RS Client API
 provide a simple environment for you to write tests.
 
-Begin by creating a test class `start/src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java`:
+Begin by creating a `start/src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java` test class:
 
 [source, java, indent=0]
 ----
@@ -237,34 +236,31 @@ a base URL string that is used throughout the tests.
 
 The `@Before` and `@After` annotations are placed on methods that execute before and after every
 test case. These methods are generally used to perform any setup and teardown tasks.
-In this case, the `setup()` method creates a JAX-RS client which makes HTTP requests to the
-inventory service. This client must also be registered with a JSON-P provider (JsrJsonpProvider)
+In this case, the `setup()` method creates a JAX-RS client that makes HTTP requests to the
+inventory service. This client must be registered with a JSON-P provider (JsrJsonpProvider)
 to process JSON resources. The `teardown()` simply destroys this client instance.
 
-Let’s break down the test cases:
-
-* `testGetPropertiesTime()` sends a request to `http://localhost:9080/inventory/systems/localhost`
-then verifies the `200` response code is returned using `connectToEndpoint()` private method. Next,
-it makes a connection to `http://localhost:9080/metrics/application` to get the content of the
-metrics as a plain text. After that, it asserts if the time needed to get the system properties for
-`localhost` is less than four seconds, using `validateMetric()` method. This test case tests
+* The `testGetPropertiesTime()` test case sends a request to the `http://localhost:9080/inventory/systems/localhost`
+URL and then verifies the `200` response code, which is returned with the `connectToEndpoint()` private method. Next,
+the test case makes a connection to `http://localhost:9080/metrics/application` to get the content of the
+metrics as plain text. After that, it uses the `validateMetric()` method to assert if the time that is needed to get the system properties for `localhost` is less than four seconds. This test case tests the
 `@Timed` annotation.
 
-* `testListCount()` sends a request to `http://localhost:9080/inventory/systems` using
-`connectToEndpoint()` method. Next, it asserts if `list()` method in `InventoryManager`
-class was invoked once using `validateMetric()` method. This test case tests `@Counted` annotation.
+* The `testListCount()` test case sends a request to the `http://localhost:9080/inventory/systems` URL with the
+`connectToEndpoint()` method. Next, it uses the `validateMetric()` method to assert if the `list()` method in the `InventoryManager`
+class was invoked once. This test case tests the `@Counted` annotation.
 
-* `testInventorySize()` sends a request to `http://localhost:9080/inventory/systems/localhost` using
-`connectToEndpoint()` method. Because of this request, the inventory grows in size resulting in
-`getHostCount()` method in `InventoryManager` class to return one host which represent the
-localhost. It then asserts that using `validateMetric()` method.
+* The `testInventorySize()` test case sends a request to the `http://localhost:9080/inventory/systems/localhost` URL with
+the `connectToEndpoint()` method. Because of this request, the inventory grows in size. The
+`getHostCount()` method in the `InventoryManager` class returns one host, which represents the
+localhost. The request then asserts the host with the `validateMetric()` method.
 
-To force these test cases to execute in a particular order, put them in a `testSuite()` method and
-label it with a `@Test` annotation so that it automatically executes when your test class run.
+To execute the test cases in a particular order, put them in a `testSuite()` method and
+label it with a `@Test` annotation, which automatically executes when your test class runs.
 
 === Running the tests
 
-Go to `start` directory and run `mvn clean install`. You should see two tests pass with the
+Go to the `start` directory and run the `mvn clean install` command. You see two tests pass with the
 following results:
 
 ```
@@ -281,8 +277,8 @@ Results :
 Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
 ```
 
-To see whether the tests detect a failure, change the assertion value(s) in `validateMetric()` method.
-`MetricsTest.java` file. Re-run the Maven build. You will see a test failure occur.
+To see if the tests detect a failure, change the assertion values in the `validateMetric()` method in the
+`MetricsTest.java` file. Rerun the Maven build. A test failure occurs.
 
 // =================================================================================================
 // Great work! You're done!
@@ -290,9 +286,8 @@ To see whether the tests detect a failure, change the assertion value(s) in `val
 
 == Great work! You're done!
 
-You have learned how to provide system and application metrics from microservices. Then you wrote tests to validate that.
+You have learned how to provide system and application metrics from microservices and then wrote tests to validate them.
 
-You can continue to try one of the related guides, which demonstrate new technologies that you can learn and
-expand on top what you built in this guide.
+Expand on what you just built by trying a related guide that demonstrates other technologies.
 
 include::{common-includes}/finish.adoc[]


### PR DESCRIPTION
We try to avoid referring to the guide itself, so could we point out the location of the directory in a different way? "The 'finish' directory in the root of this guide contains..."?

I'm wondering if we should display some of the info for @Timed, @Counted, @Guage, as well as the test cases, in a table.